### PR TITLE
prevent MYMETA.* from being included in dist

### DIFF
--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -19,6 +19,7 @@ Catalyst-View-Email-*/
 \bpm_to_blib\.ts$
 \bpm_to_blib$
 \bblibdirs\.ts$         # 6.18 through 6.25 generated this
+\bMYMETA
 
 # Avoid Module::Build generated and utility files.
 \bBuild$


### PR DESCRIPTION
Hello again :)

So! I was looking at the CPANTS metrics, and it looks like this dist was shipping the auto-generated MYMETA.* files. To avoid that, I added it to MANIFEST.SKIP.

Hope it helps! Cheers!