### PR TITLE
bumping version to 0.36

### DIFF
--- a/lib/Catalyst/Helper/View/Email.pm
+++ b/lib/Catalyst/Helper/View/Email.pm
@@ -1,6 +1,6 @@
 package Catalyst::Helper::View::Email;
 
-our $VERSION = '0.34';
+our $VERSION = '0.36';
 $VERSION = eval $VERSION;
 
 use strict;

--- a/lib/Catalyst/Helper/View/Email/Template.pm
+++ b/lib/Catalyst/Helper/View/Email/Template.pm
@@ -1,7 +1,7 @@
 package Catalyst::Helper::View::Email::Template;
 
 use strict;
-our $VERSION = '0.34';
+our $VERSION = '0.36';
 $VERSION = eval $VERSION;
 
 =head1 NAME

--- a/lib/Catalyst/View/Email.pm
+++ b/lib/Catalyst/View/Email.pm
@@ -9,7 +9,7 @@ use Email::MIME::Creator;
 use Module::Runtime;
 extends 'Catalyst::View';
 
-our $VERSION = '0.35';
+our $VERSION = '0.36';
 $VERSION = eval $VERSION;
 
 has 'mailer' => (

--- a/lib/Catalyst/View/Email/Template.pm
+++ b/lib/Catalyst/View/Email/Template.pm
@@ -5,7 +5,7 @@ use Carp;
 use Scalar::Util qw/ blessed /;
 extends 'Catalyst::View::Email';
 
-our $VERSION = '0.35';
+our $VERSION = '0.36';
 $VERSION = eval $VERSION;
 =head1 NAME
 


### PR DESCRIPTION
Heya! Me again - last time, promise :)

So, like I said, I was looking at the CPANTS result for this distribution, and it mentioned there that some files contained inconsistent `$VERSION` numbers. This patch updates all of them to the next(?) version, 0.36, which should be enough to silence that warning.

Again, hope it helps. Cheers!