### PR TITLE
call use_ok once per module

### DIFF
--- a/t/01use.t
+++ b/t/01use.t
@@ -1,3 +1,4 @@
-use Test::More tests => 1;
+use Test::More tests => 2;
 
-use_ok 'Catalyst::View::Email', 'Catalyst::View::Email::Template';
+use_ok 'Catalyst::View::Email';
+use_ok 'Catalyst::View::Email::Template';


### PR DESCRIPTION
use_ok does not accept list of module, but a single module and arguments to pass to its import method. The extra argument was being ignored, but future versions of perl are intending to make it an error to pass arguments to an undefined import method.